### PR TITLE
Added progress spinner capability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'me.tatarka:gradle-retrolambda:3.3.0-beta4'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
 

--- a/walkthrough/build.gradle
+++ b/walkthrough/build.gradle
@@ -15,7 +15,7 @@ ext {
     siteUrl = 'https://github.com/RobotsAndPencils/WalkThrough'
     gitUrl = 'https://github.com/RobotsAndPencils/WalkThrough.git'
 
-    libraryVersion = '0.0.6'
+    libraryVersion = '0.0.7'
 
     developerId = 'android'
     developerName = 'Robots & Pencils Android Team'

--- a/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/communication/WalkThroughManager.java
+++ b/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/communication/WalkThroughManager.java
@@ -31,6 +31,7 @@ import android.support.annotation.ColorRes;
 import android.support.annotation.NonNull;
 
 import com.robotsandpencils.walkthrough.presentation.main.WalkThroughActivity;
+import com.robotsandpencils.walkthrough.presentation.main.WalkThroughPresenter;
 
 import javax.inject.Singleton;
 
@@ -40,15 +41,16 @@ import javax.inject.Singleton;
  */
 
 @Singleton
-public class WalkThroughManager {
+public class WalkThroughManager implements WalkThroughPresenter.Spinner {
 
     private static WalkThroughManager sWalkThroughManager;
     public static final String WALKTHROUGH_DEFAULT_EXIT_MESSAGE = "exit_walk_through";
 
     private LayoutConfiguration mLayoutConfiguration;
-    private
+    private WalkThroughPresenter.Spinner spinner;
+
     @ColorRes
-    int mDefaultColor = android.R.color.transparent;
+    private int mDefaultColor = android.R.color.transparent;
 
     public interface Listener {
         void onWalkThroughComplete(String responseTag);
@@ -92,5 +94,23 @@ public class WalkThroughManager {
 
     public int getDefaultColor() {
         return mDefaultColor;
+    }
+
+    public void setSpinner(WalkThroughPresenter.Spinner spinner) {
+        this.spinner = spinner;
+    }
+
+    @Override
+    public void showProgress() {
+        if (spinner != null) {
+            spinner.showProgress();
+        }
+    }
+
+    @Override
+    public void hideProgress() {
+        if (spinner != null) {
+            spinner.hideProgress();
+        }
     }
 }

--- a/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/main/WalkThroughActivity.java
+++ b/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/main/WalkThroughActivity.java
@@ -29,6 +29,7 @@ import android.databinding.DataBindingUtil;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
+import android.view.View;
 
 import com.robotsandpencils.walkthrough.R;
 import com.robotsandpencils.walkthrough.databinding.ActivityWalkthroughBinding;
@@ -41,7 +42,8 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-public class WalkThroughActivity extends AppCompatActivity implements WalkThroughPresenter.View {
+public class WalkThroughActivity extends AppCompatActivity implements WalkThroughPresenter.View,
+                                                                      WalkThroughPresenter.Spinner {
 
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private ActivityWalkthroughBinding mBinding;
@@ -100,6 +102,7 @@ public class WalkThroughActivity extends AppCompatActivity implements WalkThroug
 
         mBinding = DataBindingUtil.setContentView(this, R.layout.activity_walkthrough);
         mBinding.fragmentContainer.setBackgroundColor(ContextCompat.getColor(this, mWalkThroughManager.getDefaultColor()));
+        mWalkThroughManager.setSpinner(this);
         mPresenter.attach(this);
     }
 
@@ -119,6 +122,16 @@ public class WalkThroughActivity extends AppCompatActivity implements WalkThroug
 
         mNavigator.showPagerFragment(getSupportFragmentManager(), layouts,
                 mWalkThroughManager.getLayoutConfiguration().getLayoutTheme());
+    }
+
+    @Override
+    public void showProgress() {
+        mBinding.progressFrame.setVisibility(View.VISIBLE);
+    }
+
+    @Override
+    public void hideProgress() {
+        mBinding.progressFrame.setVisibility(View.GONE);
     }
 
     @Override

--- a/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/main/WalkThroughPresenter.java
+++ b/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/main/WalkThroughPresenter.java
@@ -41,6 +41,11 @@ public class WalkThroughPresenter {
         void showWalkThrough();
     }
 
+    public interface Spinner {
+        void showProgress();
+        void hideProgress();
+    }
+
     public WalkThroughPresenter(UiThreadQueue uiThreadQueue) {
         this.mUiThreadQueue = uiThreadQueue;
     }

--- a/walkthrough/src/main/res/layout/activity_walkthrough.xml
+++ b/walkthrough/src/main/res/layout/activity_walkthrough.xml
@@ -30,6 +30,27 @@
         android:id="@+id/fragment_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@android:color/transparent" />
+        android:background="@android:color/transparent">
+
+        <FrameLayout
+            android:id="@+id/progress_frame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:alpha="0.3"
+            android:animateLayoutChanges="true"
+            android:background="@color/colorWhite"
+            android:visibility="gone">
+
+            <ProgressBar
+                android:id="@+id/progress_bar"
+                style="?android:attr/progressBarStyleLarge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:indeterminate="true"/>
+
+        </FrameLayout>
+
+    </RelativeLayout>
 
 </layout>

--- a/walkthrough/src/main/res/values/colors.xml
+++ b/walkthrough/src/main/res/values/colors.xml
@@ -26,4 +26,5 @@
 
 <resources>
     <color name="colorWhite">#FFFFFF</color>
+    <color name="colorBlack">#000000</color>
 </resources>


### PR DESCRIPTION
MYO2-118: Landing page refresh after decline
Due to an issue reported that offers in app and backend were getting out of sync we need to change the logic in apps so that
after a decline the app should request a new set of offers
standard loading spinner should be shown whilst this refresh is occurring
this applies only to offers in myo2app channel (push channel offers not impacted)
we need a new build 8.1.2 for this
the offer toaster/tile should not launch landing page in 8.1.2

How to test:
In WalkThroughScreenView add this code:
    public WalkThroughScreenView setDecline(OnClickListener listener) {
        mBinding.buttonNoThanks.setOnClickListener(listener);
        return this;
    }
In MainActivity add this code in getScreens():
        WalkThroughScreenView screen2c = new WalkThroughScreenView(this)
                .setMessage("and check the Organize Notes checkbox")
                .showBack(true)
                .showPreviousPage(true)
                .showClose(true)
                .showDeletePage(true)
                .setDecline(() ->
                    WalkThroughPresenter.Spinner spinner = (WalkThroughPresenter.Spinner)mWalkThroughManager;
                    spinner.showProgress();
                    Handler handler = new Handler();
                    handler.postDelayed(() -> spinner.hideProgress(), 5000);
                );

Run the app
Start the Walkthrough
Swipe to left
Tap Show More
Swipe left twice
Tap No Thanks
Notice spinner for 5 seconds