### PR TITLE
Feature/progress bar customisation

### DIFF
--- a/sample/src/main/java/com/robotsandpencils/walkthroughsample/MainActivity.java
+++ b/sample/src/main/java/com/robotsandpencils/walkthroughsample/MainActivity.java
@@ -26,6 +26,7 @@
 package com.robotsandpencils.walkthroughsample;
 
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
@@ -41,6 +42,8 @@ import java.util.List;
 
 public class MainActivity extends AppCompatActivity {
 
+    private WalkThroughManager mWalkThroughManager;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -48,7 +51,7 @@ public class MainActivity extends AppCompatActivity {
     }
 
     public void startWalkthrough(View v) {
-        WalkThroughManager mWalkThroughManager = WalkThroughManager.getInstance();
+        mWalkThroughManager = WalkThroughManager.getInstance();
         LayoutConfiguration layoutConfiguration = new LayoutConfiguration.Builder()
                 .addLayouts(getScreens())
                 .setLayoutTheme(new LayoutTheme.Builder()
@@ -58,6 +61,7 @@ public class MainActivity extends AppCompatActivity {
                     .setPageListExitAnimation(R.anim.out_to_top)
                     .setPageListPopEnterAnimation(R.anim.in_from_top)
                     .setPageListPopExitAnimation(R.anim.out_to_bottom)
+                    .setVerticalProgressDialog(true)
                     .build())
                 .build();
         mWalkThroughManager.start(this, layoutConfiguration, this::onClose);
@@ -95,7 +99,13 @@ public class MainActivity extends AppCompatActivity {
                 .setMessage("and check the Organize Notes checkbox")
                 .showBack(true)
                 .showPreviousPage(true)
-                .showClose(true);
+                .showClose(true)
+                .showDeletePage(true)
+                .setDecline(v -> {
+                    mWalkThroughManager.showProgress();
+                    Handler handler = new Handler();
+                    handler.postDelayed(() -> mWalkThroughManager.hideProgress(), 5000);
+                });
 
         List<Page> page2List = new ArrayList<>();
         page2List.add(new Page(screen2a, null));

--- a/sample/src/main/java/com/robotsandpencils/walkthroughsample/WalkThroughScreenView.java
+++ b/sample/src/main/java/com/robotsandpencils/walkthroughsample/WalkThroughScreenView.java
@@ -101,4 +101,9 @@ public class WalkThroughScreenView extends WalkThroughView {
         mViewModel.setDeletePageEnabled(show);
         return this;
     }
+
+    public WalkThroughScreenView setDecline(OnClickListener listener) {
+        mBinding.buttonNoThanks.setOnClickListener(listener);
+        return this;
+    }
 }

--- a/walkthrough/build.gradle
+++ b/walkthrough/build.gradle
@@ -15,7 +15,7 @@ ext {
     siteUrl = 'https://github.com/RobotsAndPencils/WalkThrough'
     gitUrl = 'https://github.com/RobotsAndPencils/WalkThrough.git'
 
-    libraryVersion = '0.0.9'
+    libraryVersion = '0.0.10'
 
     developerId = 'android'
     developerName = 'Robots & Pencils Android Team'

--- a/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/communication/LayoutTheme.java
+++ b/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/communication/LayoutTheme.java
@@ -25,6 +25,9 @@
 
 package com.robotsandpencils.walkthrough.presentation.communication;
 
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
 import android.support.annotation.ColorRes;
 import android.support.annotation.StringRes;
 
@@ -42,7 +45,7 @@ public class LayoutTheme {
 
     @ColorRes
     private int mPagerIndicatorStrokeColor = R.color.colorWhite;
-    
+
     private int mPageListEnterAnimation = R.anim.in_from_right;
 
     private int mPageListExitAnimation = R.anim.out_to_left;
@@ -53,6 +56,8 @@ public class LayoutTheme {
 
     @StringRes
     private int mProgressMessage = R.string.loading_please_wait;
+
+    private Drawable mProgressBackground = new ColorDrawable(Color.TRANSPARENT);
 
     private boolean mUseVerticalProgressDialog = false;
 
@@ -115,6 +120,14 @@ public class LayoutTheme {
         mProgressMessage = progressMessage;
     }
 
+    public Drawable getProgressBackground() {
+        return mProgressBackground;
+    }
+
+    public void setProgressBackground(Drawable progressBackground) {
+        mProgressBackground = progressBackground;
+    }
+
     public boolean useVerticalProgressDialog() {
         return mUseVerticalProgressDialog;
     }
@@ -141,6 +154,8 @@ public class LayoutTheme {
 
         @StringRes
         private int mProgressMessage = R.string.loading_please_wait;
+
+        private Drawable mProgressBackground = new ColorDrawable(Color.TRANSPARENT);
 
         private boolean mUseVerticalProgressDialog = false;
 
@@ -200,6 +215,11 @@ public class LayoutTheme {
             return this;
         }
 
+        public Builder setProgressBackground(Drawable progressBackground) {
+            mProgressBackground = progressBackground;
+            return this;
+        }
+
         public Builder setVerticalProgressDialog(boolean useVerticalProgressDialog) {
             mUseVerticalProgressDialog = useVerticalProgressDialog;
             return this;
@@ -214,6 +234,7 @@ public class LayoutTheme {
             layoutTheme.setPageListPopEnterAnimation(mPageListPopEnterAnimation);
             layoutTheme.setPageListPopExitAnimation(mPageListPopExitAnimation);
             layoutTheme.setProgressMessage(mProgressMessage);
+            layoutTheme.setProgressBackground(mProgressBackground);
             layoutTheme.setVerticalProgressDialog(mUseVerticalProgressDialog);
             return layoutTheme;
         }

--- a/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/communication/LayoutTheme.java
+++ b/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/communication/LayoutTheme.java
@@ -54,6 +54,8 @@ public class LayoutTheme {
     @StringRes
     private int mProgressMessage = R.string.loading_please_wait;
 
+    private boolean mUseVerticalProgressDialog = false;
+
     @ColorRes
     public int getPagerIndicatorFillColor() {
         return mPagerIndicatorFillColor;
@@ -113,6 +115,14 @@ public class LayoutTheme {
         mProgressMessage = progressMessage;
     }
 
+    public boolean useVerticalProgressDialog() {
+        return mUseVerticalProgressDialog;
+    }
+
+    public void setVerticalProgressDialog(boolean useVerticalProgressDialog) {
+        mUseVerticalProgressDialog = useVerticalProgressDialog;
+    }
+
     public static class Builder {
 
         @ColorRes
@@ -131,6 +141,8 @@ public class LayoutTheme {
 
         @StringRes
         private int mProgressMessage = R.string.loading_please_wait;
+
+        private boolean mUseVerticalProgressDialog = false;
 
         public Builder setPagerIndicatorFillColor(@ColorRes int pagerIndicatorFillColor) {
             mPagerIndicatorFillColor = pagerIndicatorFillColor;
@@ -188,6 +200,11 @@ public class LayoutTheme {
             return this;
         }
 
+        public Builder setVerticalProgressDialog(boolean useVerticalProgressDialog) {
+            mUseVerticalProgressDialog = useVerticalProgressDialog;
+            return this;
+        }
+
         public LayoutTheme build() {
             LayoutTheme layoutTheme = new LayoutTheme();
             layoutTheme.setPagerIndicatorFillColor(mPagerIndicatorFillColor);
@@ -197,6 +214,7 @@ public class LayoutTheme {
             layoutTheme.setPageListPopEnterAnimation(mPageListPopEnterAnimation);
             layoutTheme.setPageListPopExitAnimation(mPageListPopExitAnimation);
             layoutTheme.setProgressMessage(mProgressMessage);
+            layoutTheme.setVerticalProgressDialog(mUseVerticalProgressDialog);
             return layoutTheme;
         }
     }

--- a/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/main/WalkThroughActivity.java
+++ b/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/main/WalkThroughActivity.java
@@ -32,6 +32,8 @@ import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.TextView;
 
 import com.robotsandpencils.walkthrough.R;
 import com.robotsandpencils.walkthrough.databinding.ActivityWalkthroughBinding;
@@ -141,12 +143,21 @@ public class WalkThroughActivity extends AppCompatActivity implements WalkThroug
 
     @Override
     public void showProgress() {
-        progress = new ProgressDialog(this);
-        progress.setMessage(getString(mWalkThroughManager.getLayoutConfiguration().getLayoutTheme().getProgressMessage()));
-        progress.setIndeterminate(false);
-        progress.setProgressStyle(ProgressDialog.STYLE_SPINNER);
-        progress.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
-        progress.show();
+        if (mWalkThroughManager.getLayoutConfiguration().getLayoutTheme().useVerticalProgressDialog()) {
+            View view = View.inflate(this, R.layout.vertically_centered_progress_dialog, null);
+            TextView progressMessage = (TextView) view.findViewById(R.id.progress_message);
+            progressMessage.setText(mWalkThroughManager.getLayoutConfiguration().getLayoutTheme().getProgressMessage());
+            progress = ProgressDialog.show(this, null, null, true);
+            progress.setContentView(view);
+            progress.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        } else {
+            progress = new ProgressDialog(this);
+            progress.setMessage(getString(mWalkThroughManager.getLayoutConfiguration().getLayoutTheme().getProgressMessage()));
+            progress.setIndeterminate(false);
+            progress.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+            progress.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            progress.show();
+        }
     }
 
     @Override

--- a/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/main/WalkThroughActivity.java
+++ b/walkthrough/src/main/java/com/robotsandpencils/walkthrough/presentation/main/WalkThroughActivity.java
@@ -27,8 +27,6 @@ package com.robotsandpencils.walkthrough.presentation.main;
 
 import android.app.ProgressDialog;
 import android.databinding.DataBindingUtil;
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
@@ -39,6 +37,7 @@ import com.robotsandpencils.walkthrough.R;
 import com.robotsandpencils.walkthrough.databinding.ActivityWalkthroughBinding;
 import com.robotsandpencils.walkthrough.presentation.common.Navigator;
 import com.robotsandpencils.walkthrough.presentation.common.dependency.dagger.DaggerWrapper;
+import com.robotsandpencils.walkthrough.presentation.communication.LayoutTheme;
 import com.robotsandpencils.walkthrough.presentation.communication.WalkThroughManager;
 import com.robotsandpencils.walkthrough.presentation.main.paging.screens.Page;
 
@@ -143,20 +142,25 @@ public class WalkThroughActivity extends AppCompatActivity implements WalkThroug
 
     @Override
     public void showProgress() {
-        if (mWalkThroughManager.getLayoutConfiguration().getLayoutTheme().useVerticalProgressDialog()) {
+        LayoutTheme layoutTheme = mWalkThroughManager.getLayoutConfiguration().getLayoutTheme();
+        String message = getString(layoutTheme.getProgressMessage());
+
+        if (layoutTheme.useVerticalProgressDialog()) {
             View view = View.inflate(this, R.layout.vertically_centered_progress_dialog, null);
             TextView progressMessage = (TextView) view.findViewById(R.id.progress_message);
-            progressMessage.setText(mWalkThroughManager.getLayoutConfiguration().getLayoutTheme().getProgressMessage());
+            progressMessage.setText(message);
             progress = ProgressDialog.show(this, null, null, true);
             progress.setContentView(view);
-            progress.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
         } else {
             progress = new ProgressDialog(this);
-            progress.setMessage(getString(mWalkThroughManager.getLayoutConfiguration().getLayoutTheme().getProgressMessage()));
+            progress.setMessage(message);
             progress.setIndeterminate(false);
             progress.setProgressStyle(ProgressDialog.STYLE_SPINNER);
-            progress.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
             progress.show();
+        }
+
+        if (progress.getWindow() != null) {
+            progress.getWindow().setBackgroundDrawable(layoutTheme.getProgressBackground());
         }
     }
 

--- a/walkthrough/src/main/res/layout/vertically_centered_progress_dialog.xml
+++ b/walkthrough/src/main/res/layout/vertically_centered_progress_dialog.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/progress_container"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:orientation="vertical"
+    android:padding="@dimen/default_space">
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="?android:progressBarStyleLarge"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:indeterminate="true"/>
+
+    <TextView
+        android:id="@+id/progress_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="@dimen/default_space"
+        android:text="@string/loading_please_wait"/>
+
+</LinearLayout>

--- a/walkthrough/src/main/res/layout/vertically_centered_progress_dialog.xml
+++ b/walkthrough/src/main/res/layout/vertically_centered_progress_dialog.xml
@@ -10,7 +10,7 @@
 
     <ProgressBar
         android:id="@+id/progress_bar"
-        style="?android:progressBarStyleLarge"
+        style="?android:attr/progressBarStyleLarge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"

--- a/walkthrough/src/main/res/values/dimens.xml
+++ b/walkthrough/src/main/res/values/dimens.xml
@@ -27,4 +27,5 @@
 <resources>
     <dimen name="circle_indicator_height">25dp</dimen>
     <dimen name="circle_indicator_gap">5dp</dimen>
+    <dimen name="default_space">10dp</dimen>
 </resources>


### PR DESCRIPTION
Adds a simple vertically aligned alternate layout for the progress dialog.
Set using: `LayoutTheme.Builder().setVerticalProgressDialog(true)`

Also allows the default transparent background to be changed.
Set using: `LayoutTheme.Builder().setProgressBackground(...)`