### PR TITLE
Feature/implement ui thread queue count override

### DIFF
--- a/walkthrough/build.gradle
+++ b/walkthrough/build.gradle
@@ -15,7 +15,7 @@ ext {
     siteUrl = 'https://github.com/RobotsAndPencils/WalkThrough'
     gitUrl = 'https://github.com/RobotsAndPencils/WalkThrough.git'
 
-    libraryVersion = '0.0.10'
+    libraryVersion = '0.0.11'
 
     developerId = 'android'
     developerName = 'Robots & Pencils Android Team'

--- a/walkthrough/src/main/java/com/robotsandpencils/walkthrough/app/common/util/concurrency/threadqueue/UiThreadQueue.java
+++ b/walkthrough/src/main/java/com/robotsandpencils/walkthrough/app/common/util/concurrency/threadqueue/UiThreadQueue.java
@@ -35,8 +35,24 @@ import android.os.Looper;
 
 public class UiThreadQueue extends ThreadQueue {
 
+    private int mCount;
+
     public UiThreadQueue() {
         super(new AndroidHandlerRunner(new Handler(Looper.getMainLooper())));
+        mCount = 0;
     }
 
+    @Override
+    public boolean isEnabled() {
+        return mCount > 0;
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        mCount += enabled ? 1 : -1;
+
+        if (!isEnabled()) {
+            clear();
+        }
+    }
 }


### PR DESCRIPTION
Adds count to `UiThreadQueue`, overiding `isEnabled` and `setEnabled` methods, to prevent queue being disabled prematurely.